### PR TITLE
#33 Fix: Add setuptools dependency to resolve distutils issue in Python 3.12.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 Django==3.2.7
 pytz==2021.1
 sqlparse==0.4.1
+setuptools==75.6.0


### PR DESCRIPTION
# Description
This PR resolves the ModuleNotFoundError: No module named 'distutils' error encountered when running Django 3.2.7 on Python 3.12.8

## Changes Made:
Added setuptools to the requirements.txt file to provide the distutils module, which is removed in Python 3.12.


Now its working fine.

## References:
Resolves Issue #33 .
