### PR TITLE
Fix Issue #76: Styled the tags according to theme.

### DIFF
--- a/MyNotepad/settings.py
+++ b/MyNotepad/settings.py
@@ -50,7 +50,7 @@ INSTALLED_APPS = [
 ]
 
 # Set SITE_ID
-SITE_ID = 3  # Required for allauth
+SITE_ID = 4  # Required for allauth
 
 # Add GitHub OAuth credentials
 SOCIALACCOUNT_PROVIDERS = {

--- a/templates/notesapp/main.html
+++ b/templates/notesapp/main.html
@@ -230,6 +230,35 @@
             color: var(--primary);
         }
 
+        /* Tag Styling */
+        .note-tag {
+            display: inline-block;
+            background: linear-gradient(135deg, #2563eb, #60a5fa);
+            color: white;
+            padding: 6px 14px; /* Increased padding for better appearance */
+            border-radius: 20px; /* Rounder, pill-like shape */
+            font-size: 14px; /* Slightly larger font for readability */
+            margin-right: 8px; /* Increased margin for spacing */
+            margin-top: 6px; /* Adjusted top margin for better spacing */
+           
+            text-transform: capitalize; /* Capitalize tag text */
+            transition: background-color 0.3s, transform 0.2s ease-in-out; /* Smooth transitions for hover effects */
+        }
+
+        /* Tag Hover Effect */
+        .note-tag:hover {
+            transform: scale(1.05); /* Slightly enlarge the tag on hover */
+        }
+
+        /* Tags Container Styling */
+        .tags-container {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 2px; /* Add space between tags */
+            margin-top: 10px; /* Add margin for separation from content */
+            padding: 5px 0; /* Vertical padding for tags */
+        }
+
         footer {
             background-color: var(--surface);
             padding: 1.5rem;


### PR DESCRIPTION
Closes: #76 
Your saved notes section now looks like this:
![image](https://github.com/user-attachments/assets/093e2dfc-f223-421e-986d-76d07b8b6f2f)


