### PR TITLE
Password Toggle Feature Added

### DIFF
--- a/templates/notesapp/login.html
+++ b/templates/notesapp/login.html
@@ -423,6 +423,32 @@
 .footer-container .contact .info li i:hover,.footer-container .contact .info li a:hover{
     color:var( --primary);
 }
+
+/*password toggle feature button*/
+.password-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.password-wrapper input {
+  width: 100%;
+  padding-right: 40px; /* space for the eye icon */
+}
+
+.password-wrapper i {
+  position: absolute;
+  right: 12px;
+  cursor: pointer;
+  color: #aaa;
+  font-size: 18px;
+  transition: color 0.2s ease;
+}
+
+.password-wrapper i:hover {
+  color: #fff; /* highlight on hover */
+}
+
     </style>
 </head>
 
@@ -450,8 +476,11 @@
                 </div>
 
                 <div class="form-group">
-                    <label class="form-label" for="password">Password</label>
+                  <label class="form-label" for="password">Password</label>
+                  <div class="password-wrapper">
                     <input type="password" id="password" name="password" class="form-input" placeholder="Enter your password" required>
+                    <i class="fas fa-eye" id="toggleIcon" onclick="togglePassword()"></i>
+                  </div>
                 </div>
 
                 {% if error %}
@@ -532,6 +561,23 @@
         <p class="footer">&copy; <span id="currentYear"></span> Whitepaper. All rights reserved.</p>
     </footer>
 
+<!--    Password Toggle Feature-->
+    <script>
+        function togglePassword() {
+          const passwordField = document.getElementById("password");
+          const toggleIcon = document.getElementById("toggleIcon");
+
+          if (passwordField.type === "password") {
+            passwordField.type = "text";
+            toggleIcon.classList.remove("fa-eye");
+            toggleIcon.classList.add("fa-eye-slash"); // eye closes
+          } else {
+            passwordField.type = "password";
+            toggleIcon.classList.remove("fa-eye-slash");
+            toggleIcon.classList.add("fa-eye"); // eye opens
+          }
+        }
+    </script>
     <script>
         document.getElementById('currentYear').textContent = new Date().getFullYear();
     </script>

--- a/templates/notesapp/signup.html
+++ b/templates/notesapp/signup.html
@@ -409,6 +409,31 @@ body, html {
 .footer-container .contact .info li i:hover,.footer-container .contact .info li a:hover{
     color:var( --primary);
 }
+
+/*Password Toggle Feature*/
+.password-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.password-wrapper input {
+  width: 100%;
+  padding-right: 40px; /* space for the eye icon */
+}
+
+.password-wrapper .toggle-icon {
+  position: absolute;
+  right: 12px;
+  cursor: pointer;
+  color: #aaa;
+  font-size: 18px;
+  transition: color 0.2s ease;
+}
+
+.password-wrapper .toggle-icon:hover {
+  color: #fff; /* highlight on hover */
+}
         </style>
     </head>
 
@@ -446,13 +471,19 @@ body, html {
                 </div>
 
                 <div class="form-group">
-                    <label class="form-label" for="password">Password</label>
+                  <label class="form-label" for="password">Password</label>
+                  <div class="password-wrapper">
                     <input type="password" id="password" name="password" class="form-input" placeholder="Create a password" required>
+                    <i class="fas fa-eye toggle-icon" data-target="password"></i>
+                  </div>
                 </div>
 
                 <div class="form-group">
-                    <label class="form-label" for="confirm_password">Confirm Password</label>
+                  <label class="form-label" for="confirm_password">Confirm Password</label>
+                  <div class="password-wrapper">
                     <input type="password" id="confirm_password" name="confirm_password" class="form-input" placeholder="Confirm your password" required>
+                    <i class="fas fa-eye toggle-icon" data-target="confirm_password"></i>
+                  </div>
                 </div>
 
                 {% if error %}
@@ -531,7 +562,25 @@ body, html {
 
         <p class="footer">&copy; <span id="currentYear"></span> Whitepaper. All rights reserved.</p>
     </footer>
+<!--    Password Toggle Feature-->
+    <script>
+        document.querySelectorAll('.toggle-icon').forEach(icon => {
+          icon.addEventListener('click', () => {
+            const inputId = icon.getAttribute('data-target');
+            const inputField = document.getElementById(inputId);
 
+            if (inputField.type === "password") {
+              inputField.type = "text";
+              icon.classList.remove("fa-eye");
+              icon.classList.add("fa-eye-slash");
+            } else {
+              inputField.type = "password";
+              icon.classList.remove("fa-eye-slash");
+              icon.classList.add("fa-eye");
+            }
+          });
+        });
+    </script>
     <script>
         document.getElementById('currentYear').textContent = new Date().getFullYear();
     </script>


### PR DESCRIPTION
# 🔥 Add Password Toggle Feature

Based on the issue, I have called #210.
## 📌 Description
This PR introduces a **password visibility toggle** feature for both the **Login** and **Signup** pages.  
Users can now click on an eye icon inside the password input field to switch between hidden (`password`) and visible (`text`) modes.  

## ✅ Changes Made
- Added a **toggle button (eye/eye-slash icon)** inside password input fields.  
- Implemented JavaScript logic to toggle password visibility dynamically.  
- Styled the toggle icon with proper positioning and hover effects for better UX.  
- Applied the feature to:  
  - **Login Page** (Password field)  
  - **Signup Page** (Password + Confirm Password fields)  

## 🎯 Benefits
- Enhances user experience by letting users verify their entered password.  
- Reduces login/signup errors caused by mistyped passwords.  
- Matches modern UX patterns commonly seen in authentication forms.  

## 🖼️ Demo
- 👁️ Eye icon → shows password.  
- 👁️‍🗨️ Eye-slash icon → hides password.  


##Screenshots
**1.Login Page**
<img width="1891" height="852" alt="Screenshot 2025-08-17 172921" src="https://github.com/user-attachments/assets/5821ff2e-ffc8-4e80-b62b-4e33af8a09d9" />
<img width="1883" height="834" alt="Screenshot 2025-08-17 172900" src="https://github.com/user-attachments/assets/a3fa721d-a4ea-436d-9d7b-4d83a30c0f25" />

**2.Signup Page**
<img width="1884" height="1020" alt="Screenshot 2025-08-17 173129" src="https://github.com/user-attachments/assets/7f31b502-0bf3-4f03-bc6a-a0cd4934e7f8" />
<img width="1902" height="1025" alt="Screenshot 2025-08-17 172946" src="https://github.com/user-attachments/assets/3e73aaed-ebfe-4a62-84c7-be9879b35956" />



@ygowthamr I am the GSSOC'25 Contributor, so please label it please if you liked my changes and also please label the difficulty

Thank You,
Keyur Sherke



